### PR TITLE
Create img folder

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,6 +49,7 @@ else
 
   cp ../projects/first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
   cp ../projects/first-website-hs/img/gitpod-name-new-file.png ../project-instructions/img
+  cp ../projects/first-website-hs/img/second-shot.png ../project-instructions/img
   cp ../projects/first-website-hs/img/gitpod-toggle-preview.png ../project-instructions/img
 
   cp ../projects/bouncing-box/img/bouncing-box.gif ../project-instructions/img

--- a/setup.sh
+++ b/setup.sh
@@ -47,16 +47,16 @@ else
   cd ../project-instructions
   mkdir img
 
-  cp first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
-  cp first-website-hs/img/gitpod-name-new-file.png ../project-instructions/img
-  cp first-website-hs/img/gitpod-toggle-preview.png ../project-instructions/img
+  cp ../projects/first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
+  cp ../projects/first-website-hs/img/gitpod-name-new-file.png ../project-instructions/img
+  cp ../projects/first-website-hs/img/gitpod-toggle-preview.png ../project-instructions/img
 
-  cp bouncing-box/img/bouncing-box.gif ../project-instructions/img
-  cp bouncing-box/img/collisionDetection.png ../project-instructions/img
-  cp bouncing-box/img/changeOfSpeed.png ../project-instructions/img
-  cp bouncing-box/img/wiggle_bug.gif ../project-instructions/img
+  cp ../projects/bouncing-box/img/bouncing-box.gif ../project-instructions/img
+  cp ../projects/bouncing-box/img/collisionDetection.png ../project-instructions/img
+  cp ../projects/bouncing-box/img/changeOfSpeed.png ../project-instructions/img
+  cp ../projects/bouncing-box/img/wiggle_bug.gif ../project-instructions/img
 
-  cp circularity/img/screenBounds.png ../project-instructions/img
+  cp ../projects/circularity/img/screenBounds.png ../project-instructions/img
 
   cd ../projects
 

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ else
   cp circularity/README.md ../project-instructions/circularity.md
 
   # add images used in READMEs into project-instructions/img folder
-  cd project-instructions
+  cd ../project-instructions
   mkdir img
 
   cp first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
@@ -58,7 +58,7 @@ else
 
   cp circularity/img/screenBounds.png ../project-instructions/img
 
-  cd ..
+  cd ../projects
 
   #Cleanup first website and portfolio
   rm -rf first-website-hs portfolio-hs

--- a/setup.sh
+++ b/setup.sh
@@ -43,6 +43,20 @@ else
   cp bouncing-box/README.md ../project-instructions/bouncing-box.md
   cp circularity/README.md ../project-instructions/circularity.md
 
+  # add images used in READMEs into project-instructions/img folder
+  mkdir project-instructions/img
+
+  cp first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
+  cp first-website-hs/img/gitpod-name-new-file.png ../project-instructions/img
+  cp first-website-hs/img/gitpod-toggle-preview.png ../project-instructions/img
+
+  cp bouncing-box/img/bouncing-box.gif ../project-instructions/img
+  cp bouncing-box/img/collisionDetection.png ../project-instructions/img
+  cp bouncing-box/img/changeOfSpeed.png ../project-instructions/img
+  cp bouncing-box/img/wiggle_bug.gif ../project-instructions/img
+
+  cp circularity/img/screenBounds.png ../project-instructions/img
+
   #Cleanup first website and portfolio
   rm -rf first-website-hs portfolio-hs
 

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,8 @@ else
   cp circularity/README.md ../project-instructions/circularity.md
 
   # add images used in READMEs into project-instructions/img folder
-  mkdir project-instructions/img
+  cd project-instructions
+  mkdir img
 
   cp first-website-hs/img/gitpod-create-new-file.png ../project-instructions/img
   cp first-website-hs/img/gitpod-name-new-file.png ../project-instructions/img
@@ -56,6 +57,8 @@ else
   cp bouncing-box/img/wiggle_bug.gif ../project-instructions/img
 
   cp circularity/img/screenBounds.png ../project-instructions/img
+
+  cd ..
 
   #Cleanup first website and portfolio
   rm -rf first-website-hs portfolio-hs


### PR DESCRIPTION
-This PR creates an `img` folder inside of `project-instructions` when the setup scripts are run. This new folder houses all of the images that the READMEs load up so they are viewable when looking at directions in Gitpod


To test this new branch in gitpod:

1. Work in a new workspace without any folders.
2. Run the following commands:

- git clone https://github.com/OperationSpark/fsd-setup.git
- **cd fsd-setup**
- **git checkout create-img-folder**
- **cd ..**
- npm install -g opspark
- chmod +x fsd-setup/setup.sh
- ./fsd-setup/setup.sh

3. Now view each of the project instructions and check that there are no dead images still showing.